### PR TITLE
change `let` to `var` in function `AMTgetTeXsymbol`

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,7 +476,7 @@ Each terminal symbol is translated into a corresponding mathml node.*/
 var AMnestingDepth, AMpreviousSymbol, AMcurrentSymbol;
 
 function AMTgetTeXsymbol(symb) {
-  let pre = '';
+  var pre = '';
   if (typeof symb.val == "boolean" && symb.val) {
     pre = '';
   } else {


### PR DESCRIPTION
sometimes the ES6 `let` causes error during webpack building. Changing it to `var` solves this problem.